### PR TITLE
Adjust header logo and name spacing

### DIFF
--- a/index.html
+++ b/index.html
@@ -58,7 +58,7 @@
     <!-- Header & Navigation -->
     <header class="bg-light-bg shadow-lg sticky top-0 z-50">
         <nav class="w-full px-4 py-4 flex justify-between items-center">
-            <a href="#" class="flex items-center space-x-3">
+            <a href="#" class="flex items-center">
                 <img src="/logo.png" alt="Advent AI" class="h-8 w-8 rounded-md shadow-sm bg-light-bg" />
                 <span class="text-2xl font-bold text-primary-purple tracking-wide">Advent AI</span>
             </a>


### PR DESCRIPTION
Remove `space-x-3` from the header link to eliminate the space between the logo and the site name.

---
<a href="https://cursor.com/background-agent?bcId=bc-60757a6c-23e8-4e81-95fc-462b6dbd1f49">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-60757a6c-23e8-4e81-95fc-462b6dbd1f49">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

